### PR TITLE
`Environments`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Olive"
 uuid = "724ecaf6-c7a0-4c22-b37e-0bb7b4193da8"
 authors = ["emmac <emmettgb@gmail.com>"]
-version = "0.0.8"
+version = "0.0.81"
 
 [deps]
 IPyCells = "f2c63c6a-782d-45ad-850e-588fc6f0abf6"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ I thank you for all of your help with our project, or just for considering contr
 When submitting issues for Olive, it is important to make sure of a few things.
 1. You have replicated the issue on `Olive#Unstable`
 2. The issue does not currently exist.
-3. This is an issue with Olive, not a dependency; if there is a problem with highlighting, please report that issue to [ToolipsMarkdown](https://github.com/ChifiSource/ToolipsMarkdown.jl). If there is an issue with Cell reading/writing, report that issue to [IPyCells](https://github.com/ChifiSource/IPyCells.jl)
+3. **Pull Request TO UNSTABLE**
+4. This is an issue with Olive, not a dependency; if there is a problem with highlighting, please report that issue to [ToolipsMarkdown](https://github.com/ChifiSource/ToolipsMarkdown.jl). If there is an issue with Cell reading/writing, report that issue to [IPyCells](https://github.com/ChifiSource/IPyCells.jl)
 ### tech stack
 I appreciate those who are interested to take some time to look into the tech-stack used to create this project. I created a lot of these, and it took a lot of time.
 

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -420,7 +420,7 @@ function build(c::Connection, cell::Cell{:toml},
                         end for k in keys(c[:OliveCore].open[getname(c)].open)]
                     end
                     append!(cm, hiddencell, b)
-                end for proj in c[:OliveCore].open[getname(c)].open]
+                end for proj in c[:OliveCore].open[getname(c)].projects]
             end
             insert!(hiddencell[:children], 2, activatebutton)
         end
@@ -867,14 +867,14 @@ function evaluate(c::Connection, cm2::ComponentModifier, cell::Cell{:code},
         execcode::String = *("begin\n", rawcode, "\nend\n")
         # get project
         selected::String = cm["olivemain"]["selected"]
-        proj::Project{<:Any} = c[:OliveCore].open[getname(c)]
+        proj::Project{<:Any} = c[:OliveCore].open[getname(c)][window]
         ret::Any = ""
         p = Pipe()
         err = Pipe()
         standard_out::String = ""
         redirect_stdio(stdout = p, stderr = err) do
             try
-                ret = proj.open[window][:mod].evalin(Meta.parse(execcode))
+                ret = proj[:mod].evalin(Meta.parse(execcode))
             catch e
                 ret = e
             end
@@ -1125,7 +1125,7 @@ inputcell_style (generic function with 1 method)
 function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:tomlvalues},
     cells::Vector{Cell}, window::String)
     curr = cm["cell$(cell.id)"]["text"]
-    proj = c[:OliveCore].open[getname(c)]
+    proj = c[:OliveCore].open[getname(c)][window]
     varname = "data"
     if length(curr) > 2
         if contains(curr[1:2], "[")
@@ -1136,7 +1136,6 @@ function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:tomlvalues},
         end
     end
     evalstr = "$varname = TOML.parse(\"\"\"$(curr)\"\"\")[\"$varname\"]"
-    mod = proj.open[window][:mod]
     if ~(:TOML in names(mod))
         evalstr = "using TOML;" * evalstr
     end
@@ -1145,7 +1144,7 @@ function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:tomlvalues},
     err = Pipe()
     redirect_stdio(stdout = p, stderr = err) do
         try
-            ret = proj.open[window][:mod].evalin(Meta.parse(evalstr))
+            ret = proj[:mod].evalin(Meta.parse(evalstr))
         catch e
             ret = e
         end

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -449,7 +449,7 @@ exp::Bool = false)
 end
 
 """
-### Project{name <: Any} <: Toolips.Servable
+### Project{name <: Any}
 - name::String
 - dir::String
 - directories::Vector{Directory{<:Any}}
@@ -465,7 +465,7 @@ cells and directories
 ##### constructors
 - Directory(uri::String, access::Pair{String, String} ...; dirtype::String = "olive")
 """
-mutable struct Project{name <: Any} <: Servable
+mutable struct Project{name <: Any}
     name::String
     data::Dict{Symbol, Any}
     Project{T}(name::String,
@@ -498,25 +498,23 @@ create an OliveaExtension and
 
 ```
 """
-function build(c::AbstractConnection, cm::ComponentModifier, p::Project{<:Any};
-    at::String = first(p.open)[1])
-    name = at
-    frstcells::Vector{Cell} = p.open[at][:cells]
+function build(c::AbstractConnection, cm::ComponentModifier, p::Project{<:Any})
+    frstcells::Vector{Cell} = p[:cells]
     retvs = Vector{Servable}()
     [begin
         push!(retvs, Base.invokelatest(c[:OliveCore].olmod.build, c, cm, cell,
-        frstcells, name))
+        frstcells, p.name))
     end for cell in frstcells]
-    overwindow = div("$(name)over")
+    overwindow = div("$(p.name)over")
     style!(overwindow, "display" => "inline-block",
     "min-width" => 50percent,
     "padding" => 0px, "margin-top" => 2px, "overflow" => "hidden",
     "height" => 95percent)
-    proj_window = div(name)
+    proj_window = div(p.name)
     style!(proj_window, "border-width" => 2px, "border-style" => "solid",
     "overflow-y" => "scroll !important", "height" => 92percent, "min-width" => 40percent)
     proj_window[:children] = retvs
-    push!(overwindow, build_tab(c, name), proj_window)
+    push!(overwindow, build_tab(c, p.name), proj_window)
     overwindow::Component{:div}
 end
 
@@ -530,12 +528,11 @@ can_write(c::Connection, p::Project{<:Any}) = contains("w", d.access[group(c)])
 
 mutable struct Environment
     name::String
-    directories::Vector{Directory{<:Any}}
-    projects::Vector{Project{<:Any}}
-    function Environment(name::String,
-        dirs::Vector{Directory{<:Any}} = Vector{Directory{<:Any}}(),
-        projects::Vector{Project{<:Any}} = Vector{Project{<:Any}}())
-        new(name, dirs, projects)::Environment
+    directories::Vector{Directory}
+    projects::Vector{Project}
+    function Environment(name::String)
+        new(name, Vector{Directory}(),
+        Vector{Project}())::Environment
     end
 end
 
@@ -566,7 +563,7 @@ mutable struct OliveCore <: ServerExtension
         client_data = Dict{String, Dict{String, Any}}()
         client_keys::Dict{String, String} = Dict{String, String}()
         new(m, [:connection], data, Dict{String, String}(),
-        client_data, projopen, client_keys)
+        client_data, open, client_keys)
     end
 end
 

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -291,7 +291,7 @@ exp::Bool = false)
     container = div(dir.uri, align = "left")
     style!(container, "overflow" => "hidden")
     dirinfocont = div("dirinfocont$(dir.uri)")
-    style!(dirinfocont, "overflow" => "visible")
+    style!(dirinfocont, "overflow" => "visible", "display" => "flex")
     if "Project.toml" in readdir(dir.uri)
         toml_cats = TOML.parse(read(dir.uri * "/Project.toml",
         String))
@@ -299,15 +299,17 @@ exp::Bool = false)
             projname = toml_cats["name"]
             envtop = a("headingenv$(dir.uri)", text = projname)
             style!(envtop, "padding" => 6px, "background-color" => "blue",
-            "font-size" => 15pt, "font-weight" => "bold",
-            "border-radius" => 3px, "color" => "white")
+            "font-size" => 15pt, "font-weight" => "bold"
+            ,
+            "border-radius" => 3px, "color" => "white", "display" => "inline-block")
             push!(dirinfocont, envtop)
         end
         if "type" in keys(toml_cats)
             projtype = toml_cats["type"]
             projtop = a("typeenv$(dir.uri)", text = projtype)
             style!(projtop, "padding" => 6px, "background-color" => "darkgreen",
-            "font-size" => 15pt, "border-radius" => 3px, "color" => "white")
+            "font-size" => 15pt, "border-radius" => 3px, "color" => "white",
+            "display") => "inline-block"
             push!(dirinfocont, projtype)
         end
     end
@@ -318,8 +320,7 @@ exp::Bool = false)
     dirtop = a("heading$(dir.uri)", text = join(dirtext, "/"))
     style!(dirtop, "color" => "white", "background-color" => "darkblue",
     "font-size" => 10pt, "border-radius" => 12px, "margin-left" => 5px,
-    "font-weight" => "bold",
-    "padding" => 7px)
+    "font-weight" => "bold", "padding" => 7px, "display" => "inline-block")
     push!(dirinfocont, dirtop)
     cells = [begin
         Base.invokelatest(m.build, c, cell, dir, explorer = exp)

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -138,7 +138,7 @@ main = route("/session") do c::Connection
     ui_explorer[:children] = Vector{Servable}([begin
    Base.invokelatest(olmod.build, c, d, olmod, exp = true)
     end for d in env.directories])
-    olivemain::Component{:div} = olive_main(first(proj_open.open)[1])
+    olivemain::Component{:div} = olive_main(env.projects[1].name)
     style!(olivemain, "overflow-x" => "scroll", "position" => "relative",
     "width" => 100percent, "overflow-y" => "hidden",
     "height" => 90percent, "display" => "inline-flex")

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -126,7 +126,7 @@ main = route("/session") do c::Connection
     write!(c, olivesheet())
     c[:OliveCore].client_data[getname(c)]["selected"] = "session"
     olmod::Module = c[:OliveCore].olmod
-    proj_open::Project{<:Any} = c[:OliveCore].open[getname(c)]
+    env::Environment = c[:OliveCore].open[getname(c)]
     # setup base UI
     notifier::Component{:div} = olive_notific()
     ui_topbar::Component{:div} = topbar(c)
@@ -137,7 +137,7 @@ main = route("/session") do c::Connection
     style!(ui_settings, "position" => "sticky")
     ui_explorer[:children] = Vector{Servable}([begin
    Base.invokelatest(olmod.build, c, d, olmod, exp = true)
-    end for d in proj_open.directories])
+    end for d in env.directories])
     olivemain::Component{:div} = olive_main(first(proj_open.open)[1])
     style!(olivemain, "overflow-x" => "scroll", "position" => "relative",
     "width" => 100percent, "overflow-y" => "hidden",
@@ -147,9 +147,11 @@ main = route("/session") do c::Connection
     push!(bod, notifier,  ui_explorer, ui_topbar, ui_settings, olivemain)
     script!(c, "load", type = "Timeout", time = 250) do cm::ComponentModifier
         load_extensions!(c, cm, olmod)
-        window::Component{:div} = Base.invokelatest(olmod.build, c,
-        cm, proj_open)
-        append!(cm, "olivemain", window)
+        [begin
+            window::Component{:div} = Base.invokelatest(olmod.build, c,
+            cm, proj)
+            append!(cm, "olivemain", window)
+        end for proj in env.projects]
     end
     write!(c, bod)
 end
@@ -493,6 +495,7 @@ function start(IP::String = "127.0.0.1", PORT::Integer = 8000;
     else
         config = TOML.parse(read("$homedirec/olive/Project.toml", String))
         Pkg.activate("$homedirec/olive")
+        Pkg.instantiate()
         oc.data = config["olive"]
         rootname = oc.data["root"]
         oc.client_data = config["oliveusers"]

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -358,7 +358,7 @@ function load_session(c::Connection, cs::Vector{Cell{<:Any}},
     cm::ComponentModifier, source::String, fpath::String, d::Directory{<:Any};
     type::String = "olive")
     fsplit::Vector{SubString} = split(fpath, "/")
-    uriabove::String = join(fsplit[1:length(fsplit) - 1])
+    uriabove::String = join(fsplit[1:length(fsplit) - 2], "/")
     environment::String = ""
     if "Project.toml" in readdir(d.uri)
         environment = d.uri
@@ -411,11 +411,9 @@ function add_to_session(c::Connection, cs::Vector{Cell{<:Any}},
         return
     end
     fsplit::Vector{SubString} = split(fpath, "/")
-    uriabove::String = join(fsplit[1:length(fsplit) - 1])
+    uriabove::String = join(fsplit[1:length(fsplit) - 1], "/")
     environment::String = ""
-    if "Project.toml" in readdir(d.uri)
-        environment = d.uri
-    elseif "Project.toml" in readdir(uriabove)
+    if "Project.toml" in readdir(uriabove)
         environment = uriabove
     else
         environment = c[:OliveCore].data["home"]


### PR DESCRIPTION
So the project structure has been aching for another more appropriate and better-organized step for a while... I have now implemented the `Environment`. This simplifies the overall client structure, in its prior form there was a project open with dictionaries beneath it. Now there instead is an environment which encompasses all projects. The main advantage that this provides is the ability to work with projects more as parametric types. The two functions that accompany this are `check!(::Project{<:Any})` and `source_module!(::Project{<:Any}, ::String)` where the `String` in the latter method is the module's name -- usually the file name prior to the dots.