### PR TITLE
Finalized windowing

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -568,7 +568,7 @@ function build(c::AbstractConnection, cm::ComponentModifier, p::Project{<:Any})
         Base.invokelatest(c[:OliveCore].olmod.build, c, cm, cell,
         frstcells, p.name)::Component{<:Any}
     end for cell in frstcells])
-    proj_window::Component{:div} = div(p.name)
+    proj_window::Component{:div} = div(replace(p.name, " " => ""))
     proj_window[:children] = retvs
     style!(proj_window, "overflow-y" => "scroll", "overflow-x" => "hidden")
     proj_window::Component{:div}

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -248,6 +248,7 @@ main = route("/") do c::Connection
             append!(cm, "pane_$(proj.data[:pane])", window)
             append!(cm, "pane_$(proj.data[:pane])_tabs", build_tab(c, proj))
         end for proj in env.projects]
+        ToolipsSession.insert!(cm, "projectexplorer", 1, work_menu(c))
         if length(env.projects) > 1
             style!(cm, "pane_container_two", "width" => 100percent, "opacity" => 100percent)
         end

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -246,7 +246,7 @@ main = route("/") do c::Connection
             window::Component{:div} = Base.invokelatest(olmod.build, c,
             cm, proj)
             append!(cm, "pane_$(proj.data[:pane])", window)
-            append!(cm, "pane_$(proj.data[:pane])_tabs", build_tab(c, proj.name))
+            append!(cm, "pane_$(proj.data[:pane])_tabs", build_tab(c, proj))
         end for proj in env.projects]
         if length(env.projects) > 1
             style!(cm, "pane_container_two", "width" => 100percent, "opacity" => 100percent)

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -435,10 +435,14 @@ function close_project(c::Connection, cm2::ComponentModifier, name::String)
             )]))
         end
         append!(cm2, "pane_one_tabs", build_tab(c, lastproj.name))
-        style!(cm2, "pane_container_two", "width" => 0percent, "opacity" => 0percent)        
+        style!(cm2, "pane_container_two", "width" => 0percent, "opacity" => 0percent) 
+        pos = findfirst(proj -> proj.name == name,
+        projs)
+        deleteat!(projs, pos)
+        return       
     end
-    remove!(cm2, "$(fname)")
-    remove!(cm2, "tab$(fname)")
+    remove!(cm2, "$nname")
+    remove!(cm2, "tab$(nname)")
     [println(e => proj.name) for (e, proj) in enumerate(c[:OliveCore].open[getname(c)].projects)]
     pos = findfirst(proj -> proj.name == name,
     projs)

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -382,32 +382,46 @@ function add_to_session(c::Connection, cs::Vector{Cell{<:Any}},
     Base.invokelatest(c[:OliveCore].olmod.Olive.source_module!, myproj, source)
     Base.invokelatest(c[:OliveCore].olmod.Olive.check!, myproj)
     push!(c[:OliveCore].open[getname(c)].projects, myproj)
-    tab::Component{:div} = build_tab(c, myproj.name)
+    tab::Component{:div} = build_tab(c, myproj)
     open_project(c, cm, myproj, tab)    
 end
 
 function open_project(c::Connection, cm::AbstractComponentModifier, proj::Project{<:Any}, tab::Component{:div})
-    n_projects::Int64 = length(c[:OliveCore].open[getname(c)].projects)
+    projects = c[:OliveCore].open[getname(c)].projects
+    n_projects::Int64 = length(projects)
+    projbuild = build(c, cm, proj)
     if(n_projects == 2)
         style!(cm, "pane_container_two", "width" => 100percent, "opacity" => 100percent)
-        projbuild = build(c, cm, proj)
         proj.data[:pane] = "two"
         append!(cm, "pane_two", projbuild)
         append!(cm, "pane_two_tabs", tab)
         return
     elseif(n_projects == 1)
         proj.data[:pane] = "one"
-        projbuild = build(c, cm, proj)
         append!(cm, "pane_one", projbuild)
         append!(cm, "pane_one_tabs", tab)
         return
     end
     if(cm["olivemain"]["pane"] == "1")
-        append!(cm, "pane_one_tabs", tab)
         proj.data[:pane] = "one"
+        inpane = findall(p::Project{<:Any} -> p[:pane] == "one", projects)
+        [begin
+            if projects[p].id != proj.id 
+                style!(cm, """tab$(replace(projects[p].name, " " => ""))""", "background-color" => "lightgray")
+            end
+        end  for p in inpane]
+        append!(cm, "pane_one_tabs", tab)
+        set_children!(cm, "pane_one", [projbuild])
     else
-        append!(cm, "pane_two_tabs", tab)
         proj.data[:pane] = "two"
+        inpane = findall(p::Project{<:Any} -> p[:pane] == "two", projects)
+        [begin
+            if projects[p].id != proj.id 
+                style!(cm, """tab$(replace(projects[p].name, " " => ""))""", "background-color" => "lightgray")
+            end
+        end  for p in inpane]
+        append!(cm, "pane_two_tabs", tab)
+        set_children!(cm, "pane_two", [projbuild])
     end
 end
 
@@ -420,44 +434,43 @@ function close_project(c::Connection, cm2::ComponentModifier, name::String)
     fname = replace(name, " " => "")
     projs = c[:OliveCore].open[getname(c)].projects
     n_projects::Int64 = length(projs)
+    nname = replace(name, " " => "")
+    remove!(cm2, "$nname")
+    remove!(cm2, "tab$(nname)")
     if(n_projects == 1)
-
     elseif n_projects == 2
         lastproj = findfirst(pre -> pre.name != name, projs)
         lastproj = projs[lastproj]
         if(lastproj.data[:pane] == "two")
+            lpjn = replace(lastproj.name, " " => "")
+            remove!(cm2, lpjn)
+            remove!(cm2, "tab$lpjn")
             lastproj.data[:pane] = "one"
-            nname = replace(name, " " => "")
-            remove!(cm2, "$nname")
-            remove!(cm2, "tab$(nname)")
             set_children!(cm2, "pane_one", Vector{Servable}([
                 Base.invokelatest(c[:OliveCore].olmod.build, c, cm2, lastproj
             )]))
+            append!(cm2, "pane_one_tabs", build_tab(c, lastproj))
         end
-        append!(cm2, "pane_one_tabs", build_tab(c, lastproj.name))
-        style!(cm2, "pane_container_two", "width" => 0percent, "opacity" => 0percent) 
-        pos = findfirst(proj -> proj.name == name,
-        projs)
-        deleteat!(projs, pos)
-        return       
+        style!(cm2, "pane_container_two", "width" => 0percent, "opacity" => 0percent)  
     end
-    remove!(cm2, "$nname")
-    remove!(cm2, "tab$(nname)")
-    [println(e => proj.name) for (e, proj) in enumerate(c[:OliveCore].open[getname(c)].projects)]
     pos = findfirst(proj -> proj.name == name,
     projs)
     deleteat!(projs, pos)
     olive_notify!(cm2, "project $(fname) closed", color = "blue")
 end
 
-function build_tab(c::Connection, name::String)
+function build_tab(c::Connection, p::Project{<:Any}; hidden::Bool = false)
+    name = p.name
     fname = replace(name, " " => "")
     tabbody = div("tab$(fname)")
     style!(tabbody, "border-bottom-right-radius" => 0px,
     "border-bottom-left-radius" => 0px, "display" => "inline-block",
     "border-width" => 2px, "border-color" => "lightblue",
     "border-style" => "solid", "margin-bottom" => "0px", "cursor" => "pointer",
-    "margin-left" => 0px)
+    "margin-left" => 0px, "transition" => 1seconds)
+    if(hidden)
+        style!(tabbody, "background-color" => "gray")
+    end
     tablabel = a("tablabel$(fname)", text = name)
     style!(tablabel, "font-weight" => "bold", "margin-right" => 5px,
     "font-size"  => 13pt)
@@ -467,23 +480,6 @@ function build_tab(c::Connection, name::String)
             closebutton = topbar_icon("$(fname)close", "close")
             on(c, closebutton, "click") do cm2::ComponentModifier
                 close_project(c, cm2, name)
-            end
-            savebutton = topbar_icon("$(fname)save", "save")
-            on(c, savebutton, "click") do cm2::ComponentModifier
-                save_type = split(fname, ".")[2]
-                savepath = c[:OliveCore].open[getname(c)][fname][:path]
-                cells = c[:OliveCore].open[getname(c)][fname][:cells]
-                savecell = Cell(1, string(save_type), fname, savepath)
-                ret = olive_save(cells, savecell)
-                if isnothing(ret)
-                    olive_notify!(cm2, "file $(savepath) saved", color = "green")
-                else
-                    olive_notify!(cm2, "file $(savepath) saved", color = "$ret")
-                end
-            end
-            saveas_button = topbar_icon("$(fname)saveas", "save_as")
-            on(c, saveas_button, "click") do cm2::ComponentModifier
-
             end
             restartbutton = topbar_icon("$(fname)restart", "restart_alt")
             on(c, restartbutton, "click") do cm2::ComponentModifier
@@ -510,11 +506,19 @@ function build_tab(c::Connection, name::String)
                 end
                 end for cell in cells]
             end
+            projects = c[:OliveCore].open[getname(c)].projects
+            inpane = findall(proj::Project{<:Any} -> proj[:pane] == p[:pane], projects)
+            [begin
+                if projects[e].id != p.id 
+                    style!(cm, """tab$(replace(projects[e].name, " " => ""))""", "background-color" => "lightgray")
+                end
+            end  for e in inpane]
+            projbuild = build(c, cm, p)
+            style!(cm, tabbody, "background-color" => "white")
+            set_children!(cm, "pane_$(p[:pane])", [projbuild])
             decollapse_button = topbar_icon("$(fname)dec", "arrow_left")
             on(c, decollapse_button, "click") do cm2::ComponentModifier
-                remove!(cm2, savebutton)
                 remove!(cm2, closebutton)
-                remove!(cm2, saveas_button)
                 remove!(cm2, add_button)
                 remove!(cm2, runall_button)
                 remove!(cm2, restartbutton)
@@ -522,14 +526,10 @@ function build_tab(c::Connection, name::String)
             end
             style!(closebutton, "font-size"  => 17pt, "color" => "red")
             style!(restartbutton, "font-size"  => 17pt, "color" => "gray")
-            style!(savebutton, "font-size"  => 17pt, "color" => "gray")
-            style!(saveas_button, "font-size"  => 17pt, "color" => "gray")
             style!(decollapse_button, "font-size"  => 17pt, "color" => "blue")
             style!(add_button, "font-size"  => 17pt, "color" => "gray")
             style!(runall_button, "font-size"  => 17pt, "color" => "gray")
             append!(cm, tabbody, decollapse_button)
-            append!(cm, tabbody, savebutton)
-            append!(cm, tabbody, saveas_button)
             append!(cm, tabbody, add_button)
             append!(cm, tabbody, restartbutton)
             append!(cm, tabbody, runall_button)
@@ -542,6 +542,20 @@ end
 UndefVarError: ComponentModifier not defined
 ==#
 #==|||==#
+
+function save_project(cm2::ComponentModifier, p::Project{<:Any})
+    fname = p.name
+    save_type = split(fname, ".")[2]
+    savepath = c[:OliveCore].open[getname(c)][fname][:path]
+    cells = c[:OliveCore].open[getname(c)][fname][:cells]
+    savecell = Cell(1, string(save_type), fname, savepath)
+    ret = olive_save(cells, savecell)
+    if isnothing(ret)
+        olive_notify!(cm2, "file $(savepath) saved", color = "green")
+    else
+        olive_notify!(cm2, "file $(savepath) saved", color = "$ret")
+    end
+end
 
 function olive_loadicon()
     srcdir = @__DIR__


### PR DESCRIPTION
Windowing is now done primarily through the `close_project` and `open_project` methods, allowing for parametric project dispatches on that front. Windows now sit in two panes rather than inline, tabs toggle between different projects which share the same pane.