### PR TITLE
Completed include cells!

### DIFF
--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -1617,10 +1617,9 @@ end
 function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:include}, 
     cells::Vector{Cell}, proj::Project{<:Any})
     path = cm["cell$(cell.id)"]["text"]
+    cell.source = path
     env = c[:OliveCore].open[getname(c)]
-    println(env.pwd * "/" * path)
     if ~(isfile(path))
-        println(path)
         olive_notify!(cm, "$path is not a file!", color = "red")
     end
     projs = c[:OliveCore].open[getname(c)].projects
@@ -1633,8 +1632,8 @@ function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:include},
             fcell = Cell(1, format, fname, path)
             new_cells = olive_read(fcell)
             inclproj = add_to_session(c, new_cells, cm, fname, 
-            path, type = "include")
-            inclproj[:mod] = proj[:mod]
+            env.pwd, type = "include")
+            inclproj.data[:mod] = proj[:mod]
             olive_notify!(cm, "file $fname included", color = "darkgreen")
             set_text!(cm, "cell$(cell.id)out", fname)
         end

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -1681,7 +1681,21 @@ end
 
 function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:module}, 
     cells::Vector{Cell}, proj::Project{<:Any})
+    modname = cm["cell$(id)"]["text"]
+    if length(findall(p -> p.id == cell.id, c[:OliveCore].open[getip(c)].projects)) > 0
 
+    elseif contains("module", cell.source)
+        
+    else
+        env = proj.data[:env]
+        new_cells = Vector{Cell}()
+        projdict = Dict{Symbol, Any}(:cells => new_cells)
+        inclproj = Project{:module}(modname, projdict)
+        inclproj.id = cell.id
+        proj.id
+        olive_notify!(cm, "module $modname added", color = "red")
+        set_text!(cm, "cell$(cell.id)out", fname)
+    end
 end
 
 function cell_highlight!(c::Connection, cm::ComponentModifier, cell::Cell{:module},

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -1696,6 +1696,7 @@ function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:module},
     proj.data[:mod].evalin("""$modname = $(cell.id)""")
     inclproj = Project{:module}(modname, projdict)
     inclproj.id = cell.id
+    push!(c[:OliveCore].open[getname(c)].projects, inclproj)
     tab = build_tab(c, inclproj)
     open_project(c, cm, inclproj, tab)
     olive_notify!(cm, "module $modname added", color = "red")

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -1587,6 +1587,7 @@ end
 
 function build(c::Connection, cm::ComponentModifier, cell::Cell{:include},
     cells::Vector{Cell}, proj::Project{<:Any})
+    projs = c[:OliveCore].open[getname(c)].projects
     tm = ToolipsMarkdown.TextStyleModifier(cell.source)
     ToolipsMarkdown.julia_block!(tm)
     builtcell::Component{:div} = build_base_cell(c, cm, cell, cells,
@@ -1616,16 +1617,28 @@ end
 function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:include}, 
     cells::Vector{Cell}, proj::Project{<:Any})
     path = cm["cell$(cell.id)"]["text"]
+    env = c[:OliveCore].open[getname(c)]
+    println(env.pwd * "/" * path)
     if ~(isfile(path))
+        println(path)
         olive_notify!(cm, "$path is not a file!", color = "red")
     end
-    formatsplit = split(path, ".")
-    fnamesplit = split(path, "/")
-    fname = fnamesplit[length(fnamesplit)]
-    format = join(formatsplit[2:length(formatsplit)])
-    fcell = Cell(1, format, fname, path)
-    new_cells = olive_read(fcell)
-    add_to_session(c, new_cells, cm, fname, path, type = "include")
+    projs = c[:OliveCore].open[getname(c)].projects
+    if cell.source != "" && length(findall(p -> p.id == cell.outputs, projs)) == 0
+        if isfile(cell.source)
+            formatsplit = split(path, ".")
+            fnamesplit = split(path, "/")
+            fname = string(fnamesplit[length(fnamesplit)])
+            format = string(join(formatsplit[2:length(formatsplit)]))
+            fcell = Cell(1, format, fname, path)
+            new_cells = olive_read(fcell)
+            inclproj = add_to_session(c, new_cells, cm, fname, 
+            path, type = "include")
+            inclproj[:mod] = proj[:mod]
+            olive_notify!(cm, "file $fname included", color = "darkgreen")
+            set_text!(cm, "cell$(cell.id)out", fname)
+        end
+    end
 end
 
 function cell_highlight!(c::Connection, cm::ComponentModifier, cell::Cell{:include},

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -487,7 +487,6 @@ mutable struct Environment
     function Environment(name::String)
         new(name, Vector{Directory}(),
         Vector{Project}(), "")::Environment
-        # TODO, set this   ^^ to user's home.
     end
 end
 

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -517,6 +517,7 @@ function add_to_session(c::Connection, cs::Vector{Cell{<:Any}},
     push!(c[:OliveCore].open[getname(c)].projects, myproj)
     tab::Component{:div} = build_tab(c, myproj)
     open_project(c, cm, myproj, tab)    
+    myproj::Project{<:Any}
 end
 
 function open_project(c::Connection, cm::AbstractComponentModifier, proj::Project{<:Any}, tab::Component{:div})

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -599,12 +599,74 @@ function close_project(c::Connection, cm2::ComponentModifier, proj::Project{<:An
 end
 
 function build_tab(c::Connection, p::Project{:include}; hidden::Bool = false)
-
+    name = p.id
+    fname = replace(name, " " => "")
+    tabbody = div("tab$(fname)")
+    style!(tabbody, "border-bottom-right-radius" => 0px,
+    "border-bottom-left-radius" => 0px, "display" => "inline-block",
+    "border-width" => 2px, "border-color" => "#333333", "border-bottom" => 0px,
+    "border-style" => "solid", "margin-bottom" => "0px", "cursor" => "pointer",
+    "margin-left" => 0px, "transition" => 1seconds, "background-color" => "#F6FAE4")
+    if(hidden)
+        style!(tabbody, "background-color" => "gray")
+    end
+    tablabel = a("tablabel$(fname)", text = p.name)
+    style!(tablabel, "font-weight" => "bold", "margin-right" => 5px,
+    "font-size"  => 13pt, "color" => "#F6FAE4")
+    push!(tabbody, tablabel)
+    on(c, tabbody, "click") do cm::ComponentModifier
+        projects = c[:OliveCore].open[getname(c)].projects
+        inpane = findall(proj::Project{<:Any} -> proj[:pane] == p[:pane], projects)
+        [begin
+            if projects[e].id != p.id 
+                style!(cm, """tab$(projects[e].id)""", "background-color" => "lightgray")
+                newtablabel = a("tab$label", text = projects[e].name)
+                style!(newtablabel, "font-weight" => "bold", "margin-right" => 5px,
+                "font-size"  => 13pt, "color" => "#A2646F")
+                set_children!(cm, """tab$(projects[e].id)""", [newtablabel])
+            end
+        end  for e in inpane]
+        projbuild = build(c, cm, p)
+        set_children!(cm, "pane_$(p[:pane])", [projbuild])
+        style!(cm, tabbody, "background-color" => "lightgreen")
+    end
+    tabbody::Component{:div}
 end
 
 
 function build_tab(c::Connection, p::Project{:module}; hidden::Bool = false)
-
+    name = p.id
+    fname = replace(name, " " => "")
+    tabbody = div("tab$(fname)")
+    style!(tabbody, "border-bottom-right-radius" => 0px,
+    "border-bottom-left-radius" => 0px, "display" => "inline-block",
+    "border-width" => 2px, "border-color" => "#333333", "border-bottom" => 0px,
+    "border-style" => "solid", "margin-bottom" => "0px", "cursor" => "pointer",
+    "margin-left" => 0px, "transition" => 1seconds, "background-color" => "#FF6C5C")
+    if(hidden)
+        style!(tabbody, "background-color" => "gray")
+    end
+    tablabel = a("tablabel$(fname)", text = p.name)
+    style!(tablabel, "font-weight" => "bold", "margin-right" => 5px,
+    "font-size"  => 13pt, "color" => "#A2646F")
+    push!(tabbody, tablabel)
+    on(c, tabbody, "click") do cm::ComponentModifier
+        projects = c[:OliveCore].open[getname(c)].projects
+        inpane = findall(proj::Project{<:Any} -> proj[:pane] == p[:pane], projects)
+        [begin
+            if projects[e].id != p.id 
+                style!(cm, """tab$(projects[e].id)""", "background-color" => "lightgray")
+                newtablabel = a("tab$label", text = projects[e].name)
+                style!(newtablabel, "font-weight" => "bold", "margin-right" => 5px,
+                "font-size"  => 13pt, "color" => "#FF6C5C")
+                set_children!(cm, """tab$(projects[e].id)""", [newtablabel])
+            end
+        end  for e in inpane]
+        projbuild = build(c, cm, p)
+        set_children!(cm, "pane_$(p[:pane])", [projbuild])
+        style!(cm, tabbody, "background-color" => "red")
+    end
+    tabbody::Component{:div}
 end
 
 function build_tab(c::Connection, p::Project{<:Any}; hidden::Bool = false)

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -543,8 +543,8 @@ function open_project(c::Connection, cm::AbstractComponentModifier, proj::Projec
         proj.data[:pane] = "one"
         inpane = findall(p::Project{<:Any} -> p[:pane] == "one", projects)
         [begin
-            if projects[p].id != proj.id 
-                style!(cm, """tab$(projects[p].id)""", "background-color" => "lightgray")
+            if projects[p].id != proj.id
+                style_tab_closed!(cm, projects[p])
             end
         end  for p in inpane]
         append!(cm, "pane_one_tabs", tab)
@@ -554,7 +554,7 @@ function open_project(c::Connection, cm::AbstractComponentModifier, proj::Projec
         inpane = findall(p::Project{<:Any} -> p[:pane] == "two", projects)
         [begin
             if projects[p].id != proj.id 
-                style!(cm, """tab$(projects[p].id)""", "background-color" => "lightgray")
+                style_tab_closed!(cm, projects[p])
             end
         end  for p in inpane]
         append!(cm, "pane_two_tabs", tab)
@@ -562,14 +562,26 @@ function open_project(c::Connection, cm::AbstractComponentModifier, proj::Projec
     end
 end
 
+function style_tab_closed!(cm::ComponentModifier, proj::Project{<:Any})
+    style!(cm, """tab$(proj.id)""", "background-color" => "lightgray")
+end
+
+function style_tab_closed!(cm::ComponentModifier, proj::Project{:include})
+    style!(cm, """tab$(proj.id)""", "background-color" => "#1E5631")
+end
+
+function style_tab_closed!(cm::ComponentModifier, proj::Project{:module})
+    style!(cm, """tab$(proj.id)""", "background-color" => "#4E0707")
+end
+
+
 #==output[code]
 UndefVarError: Cell not defined 
 ==#
 #==|||==#
 
 function close_project(c::Connection, cm2::ComponentModifier, proj::Project{<:Any})
-    name = proj.id
-    fname = replace(name, " " => "")
+    fname = p.id
     projs = c[:OliveCore].open[getname(c)].projects
     n_projects::Int64 = length(projs)
     remove!(cm2, "$name")
@@ -599,44 +611,38 @@ function close_project(c::Connection, cm2::ComponentModifier, proj::Project{<:An
 end
 
 function build_tab(c::Connection, p::Project{:include}; hidden::Bool = false)
-    name = p.id
-    fname = replace(name, " " => "")
+    fname = p.id
     tabbody = div("tab$(fname)")
     style!(tabbody, "border-bottom-right-radius" => 0px,
     "border-bottom-left-radius" => 0px, "display" => "inline-block",
     "border-width" => 2px, "border-color" => "#333333", "border-bottom" => 0px,
     "border-style" => "solid", "margin-bottom" => "0px", "cursor" => "pointer",
-    "margin-left" => 0px, "transition" => 1seconds, "background-color" => "#F6FAE4")
+    "margin-left" => 0px, "transition" => 1seconds, "background-color" => "green")
     if(hidden)
         style!(tabbody, "background-color" => "gray")
     end
     tablabel = a("tablabel$(fname)", text = p.name)
     style!(tablabel, "font-weight" => "bold", "margin-right" => 5px,
-    "font-size"  => 13pt, "color" => "#F6FAE4")
+    "font-size"  => 13pt, "color" => "white")
     push!(tabbody, tablabel)
     on(c, tabbody, "click") do cm::ComponentModifier
         projects = c[:OliveCore].open[getname(c)].projects
         inpane = findall(proj::Project{<:Any} -> proj[:pane] == p[:pane], projects)
         [begin
             if projects[e].id != p.id 
-                style!(cm, """tab$(projects[e].id)""", "background-color" => "lightgray")
-                newtablabel = a("tab$label", text = projects[e].name)
-                style!(newtablabel, "font-weight" => "bold", "margin-right" => 5px,
-                "font-size"  => 13pt, "color" => "#A2646F")
-                set_children!(cm, """tab$(projects[e].id)""", [newtablabel])
+                style_tab_closed!(cm, projects[e])
             end
         end  for e in inpane]
         projbuild = build(c, cm, p)
         set_children!(cm, "pane_$(p[:pane])", [projbuild])
-        style!(cm, tabbody, "background-color" => "lightgreen")
+        style!(cm, tabbody, "background-color" => "green")
     end
     tabbody::Component{:div}
 end
 
 
 function build_tab(c::Connection, p::Project{:module}; hidden::Bool = false)
-    name = p.id
-    fname = replace(name, " " => "")
+    fname = p.id
     tabbody = div("tab$(fname)")
     style!(tabbody, "border-bottom-right-radius" => 0px,
     "border-bottom-left-radius" => 0px, "display" => "inline-block",
@@ -648,30 +654,25 @@ function build_tab(c::Connection, p::Project{:module}; hidden::Bool = false)
     end
     tablabel = a("tablabel$(fname)", text = p.name)
     style!(tablabel, "font-weight" => "bold", "margin-right" => 5px,
-    "font-size"  => 13pt, "color" => "#A2646F")
+    "font-size"  => 13pt, "color" => "white")
     push!(tabbody, tablabel)
     on(c, tabbody, "click") do cm::ComponentModifier
         projects = c[:OliveCore].open[getname(c)].projects
         inpane = findall(proj::Project{<:Any} -> proj[:pane] == p[:pane], projects)
         [begin
             if projects[e].id != p.id 
-                style!(cm, """tab$(projects[e].id)""", "background-color" => "lightgray")
-                newtablabel = a("tab$label", text = projects[e].name)
-                style!(newtablabel, "font-weight" => "bold", "margin-right" => 5px,
-                "font-size"  => 13pt, "color" => "#FF6C5C")
-                set_children!(cm, """tab$(projects[e].id)""", [newtablabel])
+                style_tab_closed!(cm, projects[e])
             end
         end  for e in inpane]
         projbuild = build(c, cm, p)
         set_children!(cm, "pane_$(p[:pane])", [projbuild])
-        style!(cm, tabbody, "background-color" => "red")
+        style!(cm, tabbody, "background-color" => "#FF6C5C")
     end
     tabbody::Component{:div}
 end
 
 function build_tab(c::Connection, p::Project{<:Any}; hidden::Bool = false)
-    name = p.id
-    fname = replace(name, " " => "")
+    fname = p.id
     tabbody = div("tab$(fname)")
     style!(tabbody, "border-bottom-right-radius" => 0px,
     "border-bottom-left-radius" => 0px, "display" => "inline-block",
@@ -690,11 +691,7 @@ function build_tab(c::Connection, p::Project{<:Any}; hidden::Bool = false)
         inpane = findall(proj::Project{<:Any} -> proj[:pane] == p[:pane], projects)
         [begin
             if projects[e].id != p.id 
-                style!(cm, """tab$(projects[e].id)""", "background-color" => "lightgray")
-                newtablabel = a("tab$label", text = projects[e].name)
-                style!(newtablabel, "font-weight" => "bold", "margin-right" => 5px,
-                "font-size"  => 13pt, "color" => "#A2646F")
-                set_children!(cm, """tab$(projects[e].id)""", [newtablabel])
+                style_tab_closed!(cm, projects[e])
             end
         end  for e in inpane]
         projbuild = build(c, cm, p)

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -581,7 +581,7 @@ UndefVarError: Cell not defined 
 #==|||==#
 
 function close_project(c::Connection, cm2::ComponentModifier, proj::Project{<:Any})
-    fname = p.id
+    name = proj.id
     projs = c[:OliveCore].open[getname(c)].projects
     n_projects::Int64 = length(projs)
     remove!(cm2, "$name")
@@ -607,7 +607,7 @@ function close_project(c::Connection, cm2::ComponentModifier, proj::Project{<:An
     pos = findfirst(pro -> pro.id == proj.id,
     projs)
     deleteat!(projs, pos)
-    olive_notify!(cm2, "project $(fname) closed", color = "blue")
+    olive_notify!(cm2, "project $(proj.name) closed", color = "blue")
 end
 
 function build_tab(c::Connection, p::Project{:include}; hidden::Bool = false)


### PR DESCRIPTION
#28 has finally been completed -- it is almost release time. I have a few more style things to wrap up, I want more file functions and a pane switcher in `build_tab`. I want collapsible settings menus. That is it, then I need to refine the `ToolipsMarkdown` syntax highlighter -- I rewrote `string` but the marking functions need some work... As well as releasing its `itmd` method. Next I wrap up the `ClientModifier` and `clear!` additions to `ToolipsSession` before finally writing the documentation for `Olive`, then we have a full release.