### PR TITLE
`0.1.2` patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Olive"
 uuid = "724ecaf6-c7a0-4c22-b37e-0bb7b4193da8"
 authors = ["emmac <emmettgb@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 IPyCells = "f2c63c6a-782d-45ad-850e-588fc6f0abf6"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Clicking the `+` icon next to the `pwd` directory will create a new project, fil
    <img src="https://github.com/ChifiSource/image_dump/blob/main/olive/doc92sc/ext.png"></img>
 </div>
 
-Extensions can be added to `Olive` by first clicking the `+` button by your `home` directory in `Olive`, then typing the extension's URL into the name box before pressing *add*
+Extensions can be added to `Olive` by first clicking the `+` button by your `home` directory in `Olive`, then typing the extension's URL into the name box before pressing *add*. This will add the package to your Pkg environment, and add a new `using` entry for the package to your `olive.jl` home file. This could also be done manually. In `0.1.5`**+**, to use extensions with *headless* `Olive` simply load them before loading `Olive`.
 ### deploying olive
    - [`beta` deployment status](#status)
    - [creating an olive server](#creating-a-server)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align = "center">
 <img src="https://github.com/ChifiSource/image_dump/blob/main/olive/0.1/olivesave.png" width="250">
-<h6>🩷 0.1.1 🩷 (! Beta I !)</h6>
+<h6>🩷 0.1.2 🩷 (! Beta I !)</h6>
 </div>
 
 Welcome to olive! Olive is a **pure julia**, **parametric** notebook editor built on the back of Julia's **multiple dispatch**. `Olive` is able to load new features by loading new methods for its functions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align = "center">
 <img src="https://github.com/ChifiSource/image_dump/blob/main/olive/0.1/olivesave.png" width="250">
-<h6>🩷 0.1 🩷 (! Beta I !)</h6>
+<h6>🩷 0.1.1 🩷 (! Beta I !)</h6>
 </div>
 
 Welcome to olive! Olive is a **pure julia**, **parametric** notebook editor built on the back of Julia's **multiple dispatch**. `Olive` is able to load new features by loading new methods for its functions.

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -1077,10 +1077,12 @@ function cell_bind!(c::Connection, cell::Cell{<:Any}, proj::Project{<:Any}, km::
         icon = olive_loadicon()
         icon.name = "load$(cell.id)"
         icon["width"] = "16"
+        proj.data[:mod].WD = CORE.open[getname(c)].pwd
         append!(cm2, "cellside$(cell.id)", icon)
         on(c, cm2, 100) do cm::ComponentModifier
             evaluate(c, cm, cell, proj)
             remove!(cm, "load$(cell.id)")
+            CORE.open[getname(c)].pwd = proj.data[:mod].WD
         end
     end
     ToolipsSession.bind(km, keybindings["copy"]) do cm2::ComponentModifier

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -994,10 +994,6 @@ function cell_open!(c::Connection, cm::ComponentModifier, cell::Cell{<:Any},
 end
 
 function get_highlighter(c::Connection, cell::Cell{<:Any})
-    nothing::Nothing
-end
-
-function get_highlighter(c::Connection, cell::Cell{:code})
     c[:OliveCore].client_data[getname(c)]["highlighters"]["julia"]
 end
 
@@ -1591,7 +1587,7 @@ function build(c::Connection, cm::ComponentModifier, cell::Cell{:getstarted},
     doc_button::Component{:button} = button("doc_button", text = "documentation")
     style!(doc_button, "font-weight" => "bold", "cursor" => "pointer")
     on(doc_button, "click") do cl::ClientModifier
-        redirect!(cl, "https://chifidocs.com/olive", new_tab = true)
+        redirect!(cl, "https://chifidocs.com/olive/Olive", new_tab = true)
     end
     push!(buttons_box, issues_button, doc_button)
     dir::Directory{<:Any} = Directory("~/")

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -69,6 +69,9 @@ mutable struct OliveModifier <: ToolipsSession.AbstractComponentModifier
     function OliveModifier(c::Connection, cm::ComponentModifier)
         new(cm.rootc, cm.changes, c[:OliveCore].client_data[getname(c)])
     end
+    function OliveModifier(s::String)
+        new(s, Vector{String}(), Dict{String, Any}())
+    end
 end
 
 getindex(om::OliveModifier, symb::Symbol) = om.data[symb]

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -464,7 +464,7 @@ function build_groups_options(c::AbstractConnection, cm::OliveModifier)
         on(c, confirm_button, "click") do cm2::ComponentModifier
             new_gr = Group(cm2["grname"]["text"])
             push!(new_gr.load_extensions, :olivebase)
-            push!(new_gr.cells, :shellrepl, :include, :module, :pkgrepl, :NOTE, :TODO)
+            push!(new_gr.cells, :shell, :include, :module, :pkgrepl, :NOTE, :TODO)
             push!(CORE.data["groups"], new_gr)
             save_settings!(c, core = true)
             group_b = button("edit$(new_gr.name)", text = new_gr.name)

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -91,9 +91,9 @@ print(STDO::String = "", x::Any ...) = begin
     STDO * join(string(x) for x in x)
 end
 
-read(path::String, wd::String, args ...; keyargs ...) = Base.read(wd * "/$path", args ...; keyargs ...)
+read(path::AbstractString, wd::AbstractString, args ...; keyargs ...) = Base.read(wd * "/$path", args ...; keyargs ...)
 
-cd(current_path::String, to::String)::String = begin
+cd(current_path::AbstractString, to::AbstractString)::String = begin
     if to == ".."
         direc = join(split(current_path, "/")[1:end - 1], "/")
         if isdir(direc)
@@ -103,19 +103,19 @@ cd(current_path::String, to::String)::String = begin
     current_path * "/$to"
 end
 
-rm(current_path::String, path::String; keyargs ...) = Base.rm(current_path * "/$path"; keyargs ...)
+rm(current_path::AbstractString, path::AbstractString; keyargs ...) = Base.rm(current_path * "/$path"; keyargs ...)
 
-cp(current_path::String, path1::String, path2::String; keyargs ...) = Base.cp(current_path * "/$path1", 
+cp(current_path::AbstractString, path1::AbstractString, path2::AbstractString; keyargs ...) = Base.cp(current_path * "/$path1", 
     current_path * "/$path2", keyargs ...)
 
-rmdir(current_path::String, name::String; args ...) = Base.rmdir(current_path * "/$name"; args ...)
+rmdir(current_path::AbstractString, name::AbstractString; args ...) = Base.rmdir(current_path * "/$name"; args ...)
 
-touch(current_path::String, name::String) = Base.touch(current_path * "/$name")
+touch(current_path::AbstractString, name::AbstractString) = Base.touch(current_path * "/$name")
 
-mv(current_path::String, path1::String, path2::String; keyargs ...) = Base.mv(current_path * "/$path1", 
+mv(current_path::AbstractString, path1::AbstractString, path2::AbstractString; keyargs ...) = Base.mv(current_path * "/$path1", 
     current_path * "/$path2", keyargs ...)
 
-open(current_path::String, path::String, args ...; keyargs ...) = Base.open(current_path * "/$path", args ...; keyargs ...)
+open(current_path::AbstractString, path::AbstractString, args ...; keyargs ...) = Base.open(current_path * "/$path", args ...; keyargs ...)
 
 disabled = nothing
 end
@@ -155,14 +155,14 @@ function olive_module(modname::String, environment::String)
         $modname.STDO = OliveBase.print($modname.STDO, x)
         return(nothing)::Nothing
     end
-    read(path::String, args ...; keyargs ...) = OliveBase.read(path, $modname.WD, args ...; keyargs ...)
-    cd(path::String) = $modname.WD = OliveBase.cd($modname.WD, path)
-    readdir(path::String = $modname.WD) = OliveBase.readdir(path)
-    open(path::String, args ...; keyargs ...) = OliveBase.open($modname.WD, args ...; keyargs ...)
-    touch(name::String) = OliveBase.touch($modname.WD, name)
-    rmdir(name::String; args ...) = OliveBase.rmdir($modname.WD, name, args ...)
-    mv(name::String, to::String; keyargs ...) = OliveBase.mv($modname.WD, name, to)
-    cp(name::String, to::String; keyargs ...) = OliveBase.cp($modname.WD, name, to)
+    read(path::AbstractString, args ...; keyargs ...) = OliveBase.read(path, $modname.WD, args ...; keyargs ...)
+    cd(path::AbstractString) = $modname.WD = OliveBase.cd($modname.WD, path)
+    readdir(path::AbstractString = $modname.WD) = OliveBase.readdir(path)
+    open(path::AbstractString, args ...; keyargs ...) = OliveBase.open($modname.WD * "/" * path, args ...; keyargs ...)
+    touch(name::AbstractString) = OliveBase.touch($modname.WD, name)
+    rmdir(name::AbstractString; args ...) = OliveBase.rmdir($modname.WD, name, args ...)
+    mv(name::AbstractString, to::AbstractString; keyargs ...) = OliveBase.mv($modname.WD, name, to)
+    cp(name::AbstractString, to::AbstractString; keyargs ...) = OliveBase.cp($modname.WD, name, to)
     end
     """
 end

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -62,7 +62,8 @@ baremodule OliveBase
 import Base
 import Base: names, in, contains, Meta, string, join, eval
 
-disabled = [:pwd, :println, :print, :read, :cd]
+disabled = [:pwd, :println, :print, :read, :cd, :open, :touch, :cp, :rm, 
+:mv, :rmdir]
 
 for name in names(Base)
     if name in disabled
@@ -90,7 +91,7 @@ print(STDO::String = "", x::Any ...) = begin
     STDO * join(string(x) for x in x)
 end
 
-read(path::String, wd::String, args ...; keyargs ...) = read(wd * "/$path", args ...; keyargs ...)
+read(path::String, wd::String, args ...; keyargs ...) = Base.read(wd * "/$path", args ...; keyargs ...)
 
 cd(current_path::String, to::String)::String = begin
     if to == ".."
@@ -102,7 +103,19 @@ cd(current_path::String, to::String)::String = begin
     current_path * "/$to"
 end
 
-# TODO rm, cp, rmdir, touch, mv, open
+rm(current_path::String, path::String; keyargs ...) = Base.rm(current_path * "/$path"; keyargs ...)
+
+cp(current_path::String, path1::String, path2::String; keyargs ...) = Base.cp(current_path * "/$path1", 
+    current_path * "/$path2", keyargs ...)
+
+rmdir(current_path::String, name::String; args ...) = Base.rmdir(current_path * "/$name"; args ...)
+
+touch(current_path::String, name::String) = Base.touch(current_path * "/$name")
+
+mv(current_path::String, path1::String, path2::String; keyargs ...) = Base.mv(current_path * "/$path1", 
+    current_path * "/$path2", keyargs ...)
+
+open(current_path::String, path::String, args ...; keyargs ...) = Base.open(current_path * "/$path", args ...; keyargs ...)
 
 disabled = nothing
 end
@@ -143,11 +156,13 @@ function olive_module(modname::String, environment::String)
         return(nothing)::Nothing
     end
     read(path::String, args ...; keyargs ...) = OliveBase.read(path, $modname.WD, args ...; keyargs ...)
-
-    cd(path::String) = $modname.WD = OliveBase.cd(path, to)
-
+    cd(path::String) = $modname.WD = OliveBase.cd($modname.WD, path)
     readdir(path::String = $modname.WD) = OliveBase.readdir(path)
-
+    open(path::String, args ...; keyargs ...) = OliveBase.open($modname.WD, args ...; keyargs ...)
+    touch(name::String) = OliveBase.touch($modname.WD, name)
+    rmdir(name::String; args ...) = OliveBase.rmdir($modname.WD, name, args ...)
+    mv(name::String, to::String; keyargs ...) = OliveBase.mv($modname.WD, name, to)
+    cp(name::String, to::String; keyargs ...) = OliveBase.cp($modname.WD, name, to)
     end
     """
 end

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -59,7 +59,26 @@ global evalin(ex::Any) = begin
 end
 
 baremodule OliveBase
-import Base: *, vect, +, -, catch_backtrace
+import Base
+import Base: names, in, contains, Meta, string, join, eval
+
+disabled = [:pwd, :println, :print]
+
+for name in names(Base)
+    if name in disabled
+        continue
+    end
+    if contains(string(name), "#")
+        continue
+    end
+    try
+        eval(OliveBase, Meta.parse("import Base: $name"))
+        eval(OliveBase, Meta.parse("export $name"))
+    catch
+
+    end
+end
+
 println(STDO::String = "", x::Any ...) = begin
     STDO * join(string(x) for x in x) * "</br>"
 end
@@ -68,7 +87,6 @@ print(STDO::String = "", x::Any ...) = begin
     STDO * join(string(x) for x in x)
 end
 
-export *, vect, +, -, catch_backtrace
 end
 
 """export evalin

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -75,7 +75,10 @@ for name in names(Base)
         eval(OliveBase, Meta.parse("import Base: $name"))
         eval(OliveBase, Meta.parse("export $name"))
     catch
-
+        try
+            eval(OliveBase, Meta.parse("import Base: ($name)"))
+        catch
+        end
     end
 end
 
@@ -87,6 +90,7 @@ print(STDO::String = "", x::Any ...) = begin
     STDO * join(string(x) for x in x)
 end
 
+disabled = nothing
 end
 
 """export evalin

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -62,7 +62,7 @@ baremodule OliveBase
 import Base
 import Base: names, in, contains, Meta, string, join, eval
 
-disabled = [:pwd, :println, :print]
+disabled = [:pwd, :println, :print, :read, :cd]
 
 for name in names(Base)
     if name in disabled
@@ -89,6 +89,20 @@ end
 print(STDO::String = "", x::Any ...) = begin
     STDO * join(string(x) for x in x)
 end
+
+read(path::String, wd::String, args ...; keyargs ...) = read(wd * "/$path", args ...; keyargs ...)
+
+cd(current_path::String, to::String)::String = begin
+    if to == ".."
+        direc = join(split(current_path, "/")[1:end - 1], "/")
+        if isdir(direc)
+            return(direc)
+        end
+    end
+    current_path * "/$to"
+end
+
+# TODO rm, cp, rmdir, touch, mv, open
 
 disabled = nothing
 end
@@ -128,6 +142,12 @@ function olive_module(modname::String, environment::String)
         $modname.STDO = OliveBase.print($modname.STDO, x)
         return(nothing)::Nothing
     end
+    read(path::String, args ...; keyargs ...) = OliveBase.read(path, $modname.WD, args ...; keyargs ...)
+
+    cd(path::String) = $modname.WD = OliveBase.cd(path, to)
+
+    readdir(path::String = $modname.WD) = OliveBase.readdir(path)
+
     end
     """
 end

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -55,7 +55,7 @@ For example, the `:code` cell is added to `Olive` using the `Method`
 function build end
 
 global evalin(ex::Any) = begin
-    Main.eval(ex)
+    Base.eval(Main, ex)
 end
 
 """export evalin
@@ -658,6 +658,7 @@ function setup_olive(logger::Toolips.Logger, path::String)
     create_project(path)
     config::Dict{String, Any} = TOML.parse(read(
         "$path/olive/Project.toml",String))
+    Pkg.activate("$path/olive")
     log(logger, "creating user configuration")
     # users
     users::Dict{String, Any} = Dict{String, Any}(

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -58,6 +58,19 @@ global evalin(ex::Any) = begin
     Base.eval(Main, ex)
 end
 
+baremodule OliveBase
+import Base: *, vect, +, -, catch_backtrace
+println(STDO::String = "", x::Any ...) = begin
+    STDO * join(string(x) for x in x) * "</br>"
+end
+
+print(STDO::String = "", x::Any ...) = begin
+    STDO * join(string(x) for x in x)
+end
+
+export *, vect, +, -, catch_backtrace
+end
+
 """export evalin
 ```julia
 olive_module(modname::String, environment::String) -> ::String
@@ -73,23 +86,24 @@ function olive_module(modname::String, environment::String)
     """
     baremodule $(modname)
     using Pkg
-    using Base
+    using Olive.OliveBase
+    const Base = OliveBase
     global STDO::String = ""
     WD = ""
     Main = nothing
     Olive = nothing
     eval(e::Any) = Core.eval($(modname), e)
     function evalin(ex::Any)
-            Pkg.activate("$environment")
-            ret = eval(ex)
+        Pkg.activate("$environment")
+        ret = eval(ex)
     end
     pwd() = WD
     println(x::Any ...) = begin
-        $modname.STDO=$modname.STDO*join(string(x) for x in x)*"</br>"
+        $modname.STDO = OliveBase.println($modname.STDO, x)
         return(nothing)::Nothing
     end
     print(x::Any ...) = begin
-        $modname.STDO=$modname.STDO*join(string(x) for x in x)
+        $modname.STDO = OliveBase.print($modname.STDO, x)
         return(nothing)::Nothing
     end
     end

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -74,7 +74,7 @@ function olive_module(modname::String, environment::String)
     baremodule $(modname)
     using Pkg
     using Base
-    import Base: println, print
+    import Base: println, print, pwd
     global STDO::String = ""
     WD = ""
     Main = nothing
@@ -86,7 +86,8 @@ function olive_module(modname::String, environment::String)
     end
     Base.delete_method(methods(println)[3])
     Base.delete_method(methods(print)[29])
-    
+    Base.delete_method(methods(pwd)[1])
+    pwd() = WD
     println(x::Any ...) = begin
         $modname.STDO=$modname.STDO*join(string(x) for x in x)*"</br>"
         return(nothing)::Nothing

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -74,7 +74,6 @@ function olive_module(modname::String, environment::String)
     baremodule $(modname)
     using Pkg
     using Base
-    import Base: println, print, pwd
     global STDO::String = ""
     WD = ""
     Main = nothing
@@ -84,9 +83,6 @@ function olive_module(modname::String, environment::String)
             Pkg.activate("$environment")
             ret = eval(ex)
     end
-    Base.delete_method(methods(println)[3])
-    Base.delete_method(methods(print)[29])
-    Base.delete_method(methods(pwd)[1])
     pwd() = WD
     println(x::Any ...) = begin
         $modname.STDO=$modname.STDO*join(string(x) for x in x)*"</br>"

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -961,6 +961,9 @@ Completely removes a `Module` from a project, adding it back to the `OliveCore` 
 ```
 """
 function empty_module!(c::Connection, proj::Project{<:Any})
+    if ~(haskey(proj.data, :mod))
+        return(nothing)
+    end
     push!(c[:OliveCore].pool, proj.id)
     mod = proj[:mod]
     re_source!(c, proj)
@@ -1051,7 +1054,6 @@ function build_findbar(c::AbstractConnection, cm::AbstractComponentModifier, cel
             hl = get_highlighter(c, cells[active_cell])
             style!(hl, :found, "color" => "white", "font-weight" => "bold", "background-color" => "#D90166", "border-radius" => 1px)
             style!(hl, :founds, "color" => "black", "background-color" => "lightpink", "border-radius" => 1px)
-    
             # Override "pfounds" in the selected cell for better visibility
             push!(hl, position => :found)
             for pos in filter(p -> p != position, active_cell_items)

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -589,20 +589,41 @@ function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:shell},
     proj::Project{<:Any})
     curr = cm["cell$(cell.id)"]["text"]
     mod = proj[:mod]
-    p = Pipe()
-    err = Pipe()
-    standard_out::String = ""
-    ret = ""
-    redirect_stdio(stdout = p, stderr = err) do
-        try
-            mod.evalin(Meta.parse("Base.run(`$curr`)"))
-        catch e
-            ret = e
+    commands = split(curr, " ")
+    cmd = Symbol(commands[1])
+    aliased_command = cmd == :ls || cmd == :dir
+    out::String = ""
+    ret::Any = ""
+    if ~aliased_command && ~(cmd in names(proj[:mod], all = true))
+        set_text!(cm, "cell$(cell.id)out", "$(commands[1]) is not a recognized command.")
+        set_text!(cm, "cell$(cell.id)", "")
+        return
+    elseif aliased_command
+        if length(commands) == 1
+            ret = mod.readdir()
+        else
+            ret = mod.readdir(commands[2])
         end
+    else
+        args = []
+        if length(commands) > 1
+            args = commands[2:end]
+        end
+        getfield(mod, cmd)(args ...)
     end
-    close(Base.pipe_writer(p))
-    standard_out = replace(read(p, String), "\n" => "<br>")
-    set_text!(cm, "cell$(cell.id)out", standard_out)
+    active_display::OliveDisplay = OliveDisplay()
+    outp = ""
+    if typeof(ret) <: Exception
+        display(active_display, ret, Base.StackTraces.stacktrace(st_trace))
+        outp = replace(String(take!(active_display.io)), "\n" => "</br>")
+    elseif ~(isnothing(ret))
+        display(active_display, MIME"olive"(), ret)
+        outp = outp * "</br>" * String(take!(active_display.io))
+    elseif isnothing(ret)
+        outp = standard_out
+    end
+    out = mod.STDO
+    set_text!(cm, "cell$(cell.id)out", outp * out)
     set_text!(cm, "cell$(cell.id)", "")
 end
 

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -623,6 +623,9 @@ function evaluate(c::Connection, cm::ComponentModifier, cell::Cell{:shell},
         outp = standard_out
     end
     out = mod.STDO
+    if cmd == :pwd || cmd == :cd
+        out = mod.WD
+    end
     set_text!(cm, "cell$(cell.id)out", outp * out)
     set_text!(cm, "cell$(cell.id)", "")
 end


### PR DESCRIPTION
The latest patch fixes some slight issues with `0.1.2`  and also adds new features to the base `olive_module`, such as fully integrated file-system commands.
- renamed `shellrepl` in creator key defaults (by default, `;` is bound to a `:shellrepl` cell that is now named `:shell`, so it produces a `Cell{<:Any}`)
- Removed base from olive modules
- Added `OliveBase` to olive modules
- Added integrated filesystem commands to `OliveBase`
- Adjusted cell-to-cell output pattern
- Added `OliveModifier` `String` constructor
- Changed `Olive` home module initialization order.